### PR TITLE
modules/nat_traversal: avoid clang warnings with cast to (enum _hdr_types_t)

### DIFF
--- a/modules/nat_traversal/nat_traversal.c
+++ b/modules/nat_traversal/nat_traversal.c
@@ -1474,7 +1474,7 @@ FixContact(struct sip_msg *msg)
     }
 
     offset = contact->uri.s - msg->buf;
-    anchor = del_lump(msg, offset, contact->uri.len, HDR_CONTACT_F);
+    anchor = del_lump(msg, offset, contact->uri.len, (enum _hdr_types_t)HDR_CONTACT_F);
 
     if (!anchor) {
         pkg_free(buf);
@@ -1484,7 +1484,7 @@ FixContact(struct sip_msg *msg)
     len = sprintf(buf, "%.*s%s:%d%.*s", before_host.len, before_host.s,
                   newip.s, newport, after.len, after.s);
 
-    if (insert_new_lump_after(anchor, buf, len, HDR_CONTACT_F) == 0) {
+    if (insert_new_lump_after(anchor, buf, len, (enum _hdr_types_t)HDR_CONTACT_F) == 0) {
         pkg_free(buf);
         return -1;
     }


### PR DESCRIPTION
nat_traversal.c:1477:54: warning: implicit conversion from 'hdr_flags_t' (aka 'unsigned long long') to 'enum _hdr_types_t' changes value from 18446744073709551615 to -1 [-Wconstant-conversion]
nat_traversal.c:1487:49: warning: implicit conversion from 'hdr_flags_t' (aka 'unsigned long long') to 'enum _hdr_types_t' changes value from 18446744073709551615 to -1 [-Wconstant-conversion]
